### PR TITLE
feat: issue #18 sources + weekly maintenance (schema, greenhouse, oxalis)

### DIFF
--- a/scripts/scrape.ts
+++ b/scripts/scrape.ts
@@ -29,6 +29,8 @@ import { scrapeXpandIt } from './sources/custom/xpandit.js';
 import { scrapeElements } from './sources/custom/elements.js';
 import { scrapeDecadis } from './sources/custom/decadis.js';
 import { scrapeMBition } from './sources/custom/mbition.js';
+import { scrapeEmpyra } from './sources/custom/empyra.js';
+import { scrapeSngular } from './sources/custom/sngular.js';
 import {
   LEVER_SOURCES,
   ASHBY_SOURCES,
@@ -201,6 +203,8 @@ async function main() {
     { name: 'Elements',        fn: scrapeElements },
     { name: 'Decadis',         fn: scrapeDecadis },
     { name: 'MBition',         fn: scrapeMBition },
+    { name: 'Empyra',          fn: scrapeEmpyra },
+    { name: 'Sngular',         fn: scrapeSngular },
   ];
 
   for (const { name, fn } of custom) {

--- a/scripts/sources/config/greenhouse-sources.ts
+++ b/scripts/sources/config/greenhouse-sources.ts
@@ -11,6 +11,9 @@ export const GREENHOUSE_SOURCES: GreenhouseSource[] = [
   // Non-partner companies — filter to Atlassian-relevant titles only
   { slug: 'samsara',        name: 'Samsara',     titleFilter: ATLASSIAN_TITLE_FILTER },
   { slug: 'kallesgroup',    name: 'Kalles Group', titleFilter: ATLASSIAN_TITLE_FILTER },
+  { slug: 'valtech',        name: 'Valtech',      titleFilter: ATLASSIAN_TITLE_FILTER },
+  { slug: 'braze',          name: 'Braze',        titleFilter: ATLASSIAN_TITLE_FILTER },
+  { slug: 'conga',          name: 'Conga',        titleFilter: ATLASSIAN_TITLE_FILTER },
   // Partner with broad consulting roster — filter to Atlassian-relevant titles
   { slug: 'appnovation',    name: 'Appnovation Technologies', titleFilter: ATLASSIAN_TITLE_FILTER },
 ];

--- a/scripts/sources/config/greenhouse-sources.ts
+++ b/scripts/sources/config/greenhouse-sources.ts
@@ -11,4 +11,6 @@ export const GREENHOUSE_SOURCES: GreenhouseSource[] = [
   // Non-partner companies — filter to Atlassian-relevant titles only
   { slug: 'samsara',        name: 'Samsara',     titleFilter: ATLASSIAN_TITLE_FILTER },
   { slug: 'kallesgroup',    name: 'Kalles Group', titleFilter: ATLASSIAN_TITLE_FILTER },
+  // Partner with broad consulting roster — filter to Atlassian-relevant titles
+  { slug: 'appnovation',    name: 'Appnovation Technologies', titleFilter: ATLASSIAN_TITLE_FILTER },
 ];

--- a/scripts/sources/custom/empyra.ts
+++ b/scripts/sources/custom/empyra.ts
@@ -1,0 +1,57 @@
+import type { Job } from '../../types.js';
+import { buildStableJobId, normaliseLocation } from '../../utils/normalise.js';
+
+// Empyra (Atlassian Platinum Solution Partner, US/India) embeds Keka HRMS on
+// /careers. The embed JS hits this JSON endpoint for the active jobs list — we
+// call it directly. Identifier comes from the embed config on empyra.com/careers.
+const API_URL =
+  'https://empyra.keka.com/careers/api/embedjobs/default/active/4a5fd503-f542-42da-83f0-13c37c2a3af6';
+const JOB_URL_BASE = 'https://empyra.keka.com/careers/jobdetails/';
+
+interface KekaJobLocation {
+  name?: string;
+  city?: string;
+}
+
+interface KekaJob {
+  id: number;
+  title: string;
+  departmentName?: string;
+  jobLocations?: KekaJobLocation[];
+}
+
+export async function scrapeEmpyra(): Promise<Job[]> {
+  const res = await fetch(API_URL, {
+    headers: { 'User-Agent': 'ApwideJobBot/1.0' },
+  });
+
+  if (!res.ok) {
+    console.warn(`Empyra: HTTP ${res.status} — returning empty`);
+    return [];
+  }
+
+  const data = (await res.json()) as KekaJob[];
+  const now = new Date().toISOString();
+
+  return data.map((job) => {
+    const location = (job.jobLocations ?? [])
+      .map((l) => l.city || l.name || '')
+      .filter(Boolean)
+      .join(', ');
+
+    return {
+      id: buildStableJobId('empyra', String(job.id)),
+      sourceId: String(job.id),
+      source: 'Empyra',
+      title: job.title,
+      company: 'Empyra',
+      location,
+      locationNormalised: normaliseLocation(location),
+      department: job.departmentName || undefined,
+      url: `${JOB_URL_BASE}${job.id}`,
+      firstSeen: now,
+      lastSeen: now,
+      isActive: true,
+    };
+  });
+}

--- a/scripts/sources/custom/oxalis.ts
+++ b/scripts/sources/custom/oxalis.ts
@@ -8,7 +8,10 @@ export async function scrapeOxalis(): Promise<Job[]> {
     headers: { 'User-Agent': 'ApwideJobBot/1.0' },
   });
 
-  if (!res.ok) throw new Error(`Oxalis: HTTP ${res.status}`);
+  if (!res.ok) {
+    console.warn(`Oxalis: HTTP ${res.status} — returning empty`);
+    return [];
+  }
 
   const html = await res.text();
   const now = new Date().toISOString();

--- a/scripts/sources/custom/sngular.ts
+++ b/scripts/sources/custom/sngular.ts
@@ -1,0 +1,65 @@
+import type { Job } from '../../types.js';
+import { buildStableJobId, decodeEntities, normaliseLocation } from '../../utils/normalise.js';
+
+// Sngular is an Atlassian Platinum/Gold Solution Partner with a broad consulting
+// roster (data, mobile, cloud — mostly non-Atlassian). The jobs page renders all
+// roles as `m-card-job` blocks in the initial HTML, so fetch+regex is sufficient.
+// We filter to Atlassian-relevant titles to avoid flooding the board with
+// unrelated dev roles — same pattern as Samsara/Kalles Group in Greenhouse.
+const ATLASSIAN_TITLE_FILTER = /atlassian|jira|confluence|bitbucket/i;
+const CAREERS_URL = 'https://www.sngular.com/talent-and-culture/jobs';
+const BASE_URL = 'https://www.sngular.com';
+
+export async function scrapeSngular(): Promise<Job[]> {
+  const res = await fetch(CAREERS_URL, {
+    headers: { 'User-Agent': 'ApwideJobBot/1.0' },
+  });
+
+  if (!res.ok) {
+    console.warn(`Sngular: HTTP ${res.status} — returning empty`);
+    return [];
+  }
+
+  const html = await res.text();
+  const now = new Date().toISOString();
+  const jobs: Job[] = [];
+
+  // Each card opens with `<div class="m-card-job">`. Splitting on that boundary
+  // gives a clean per-card chunk without having to balance nested </div>s.
+  const cardChunks = html.split('<div class="m-card-job">').slice(1);
+
+  for (const chunk of cardChunks) {
+    const linkMatch = chunk.match(/href="(\/talent-and-culture\/jobs\/(\d+)\/[^"]+)"/);
+    if (!linkMatch) continue;
+    const relUrl = linkMatch[1];
+    const sourceId = linkMatch[2];
+
+    const titleMatch = chunk.match(/<p class="m-card-job__title[^"]*">\s*([^<]+?)\s*<\/p>/);
+    const title = decodeEntities((titleMatch?.[1] ?? '').trim());
+    if (!title) continue;
+
+    if (!ATLASSIAN_TITLE_FILTER.test(title)) continue;
+
+    // The label "Location" is followed by a sibling <p> with the value.
+    const locMatch = chunk.match(
+      /<p class="m-card-job__label[^"]*">Location<\/p>\s*<p[^>]*>\s*([^<]+?)\s*<\/p>/
+    );
+    const location = decodeEntities((locMatch?.[1] ?? '').trim());
+
+    jobs.push({
+      id: buildStableJobId('sngular', sourceId),
+      sourceId,
+      source: 'Sngular',
+      title,
+      company: 'Sngular',
+      location,
+      locationNormalised: normaliseLocation(location),
+      url: `${BASE_URL}${relUrl}`,
+      firstSeen: now,
+      lastSeen: now,
+      isActive: true,
+    });
+  }
+
+  return jobs;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,47 +61,82 @@ const categories = ['developer', 'consultancy', 'marketing-sales', 'support', 'b
   (c) => activeJobs.some((j) => normaliseCategory(j.department, j.title) === c)
 );
 
-// Derive ISO 3166-1 alpha-2 country code from what we know about the job
-// locationNormalised is an array — try specific entries before falling back to raw string
-function countryCode(normalised: string[], raw: string): string {
+// Derive ISO 3166-1 alpha-2 country code from what we know about the job.
+// Returns null when the location is too ambiguous to assign a country (e.g. "Europe", "LatAm").
+function countryCode(normalised: string[], raw: string): string | null {
   const map: Record<string, string> = {
     australia: 'AU', 'new zealand': 'NZ', singapore: 'SG',
-    'hong kong': 'HK', usa: 'US', uk: 'GB', india: 'IN',
+    'hong kong': 'HK', usa: 'US', uk: 'GB', india: 'IN', canada: 'CA',
   };
   for (const n of normalised) {
     if (n !== 'remote' && n !== 'other' && map[n]) return map[n];
   }
   const loc = raw.toLowerCase();
-  if (/australia|\(au\)/.test(loc))                              return 'AU';
-  if (/united states|[,( ]us(?:[^a-z]|$)|[,( ]usa/.test(loc))  return 'US';
-  if (/united kingdom|[,( ]uk(?:[^a-z]|$)/.test(loc))           return 'GB';
-  if (/germany|stuttgart|berlin|munich/.test(loc))               return 'DE';
-  if (/france/.test(loc))                                        return 'FR';
-  if (/new zealand/.test(loc))                                   return 'NZ';
-  if (/india/.test(loc))                                         return 'IN';
-  if (/singapore/.test(loc))                                     return 'SG';
-  return 'AU'; // fallback — Apwide is AU-based
+  if (/australia|\(au\)/.test(loc))                                  return 'AU';
+  if (/united states|[,( ]us(?:[^a-z]|$)|[,( ]usa/.test(loc))       return 'US';
+  if (/canada|ontario|vancouver|calgary|edmonton|toronto/.test(loc)) return 'CA';
+  if (/united kingdom|[,( ]uk(?:[^a-z]|$)/.test(loc))               return 'GB';
+  if (/germany|stuttgart|berlin|munich|koblenz/.test(loc))           return 'DE';
+  if (/france|paris|marseille/.test(loc))                            return 'FR';
+  if (/switzerland|z[üu]rich|bern/.test(loc))                        return 'CH';
+  if (/netherlands|amsterdam/.test(loc))                             return 'NL';
+  if (/belgium|awans/.test(loc))                                     return 'BE';
+  if (/luxembourg|esch-sur-alzette/.test(loc))                       return 'LU';
+  if (/ireland|galway|dublin/.test(loc))                             return 'IE';
+  if (/sweden|stockholm|gothenburg/.test(loc))                       return 'SE';
+  if (/finland|helsinki/.test(loc))                                  return 'FI';
+  if (/poland|wrocław|wroclaw|krakow|warsaw/.test(loc))              return 'PL';
+  if (/portugal|lisbon|lisboa|porto/.test(loc))                      return 'PT';
+  if (/\bspain\b|madrid|barcelona/.test(loc))                        return 'ES';
+  if (/\bitaly\b|rome|milan/.test(loc))                              return 'IT';
+  if (/bulgaria/.test(loc))                                          return 'BG';
+  if (/hungary|budapest/.test(loc))                                  return 'HU';
+  if (/new zealand/.test(loc))                                       return 'NZ';
+  if (/india/.test(loc))                                             return 'IN';
+  if (/singapore/.test(loc))                                         return 'SG';
+  if (/morocco|casablanca|rabat/.test(loc))                          return 'MA';
+  if (/tunisia|tunis/.test(loc))                                     return 'TN';
+  if (/egypt|cairo/.test(loc))                                       return 'EG';
+  if (/\buae\b|dubai|united arab emirates/.test(loc))               return 'AE';
+  if (/malaysia|kuala lumpur/.test(loc))                             return 'MY';
+  if (/philippines|manila/.test(loc))                                return 'PH';
+  if (/argentina/.test(loc))                                         return 'AR';
+  if (/brazil|brasil/.test(loc))                                     return 'BR';
+  if (/costa rica/.test(loc))                                        return 'CR';
+  return null;
 }
 
 const jobPostings = activeJobs.map((j) => {
+  const normArr = Array.isArray(j.locationNormalised) ? j.locationNormalised : [j.locationNormalised];
+  const BROAD_REGIONS = ['remote', 'europe', 'latam', 'africa', 'asia'];
   const isRemote =
-    j.locationNormalised.includes('remote') ||
-    j.location.toLowerCase().includes('remote');
-  const cc = countryCode(j.locationNormalised, j.location);
+    normArr.some((n) => BROAD_REGIONS.includes(n)) ||
+    j.location.toLowerCase().includes('remote') ||
+    j.location.toLowerCase() === 'global';
+  const cc = countryCode(normArr, j.location);
 
   return {
     '@type': 'JobPosting',
     title: j.title,
-    description: j.description ?? `${j.title} position at ${j.company}.`,
+    description: j.description || `${j.title} position at ${j.company}.`,
     datePosted: j.firstSeen,
     validThrough: j.lastSeen,
     hiringOrganization: { '@type': 'Organization', name: j.company },
-    jobLocation: {
-      '@type': 'Place',
-      address: { '@type': 'PostalAddress', addressCountry: cc, addressLocality: j.location },
-    },
-    ...(isRemote ? { jobLocationType: 'TELECOMMUTE' } : {}),
-    ...(isRemote ? { applicantLocationRequirements: { '@type': 'Country', name: cc } } : {}),
+    ...(isRemote
+      ? {
+          jobLocationType: 'TELECOMMUTE',
+          ...(cc ? { applicantLocationRequirements: { '@type': 'Country', name: cc } } : {}),
+        }
+      : {
+          jobLocation: {
+            '@type': 'Place',
+            address: {
+              '@type': 'PostalAddress',
+              ...(cc ? { addressCountry: cc } : {}),
+              ...(j.location ? { addressLocality: j.location } : {}),
+            },
+          },
+        }),
     url: j.url,
   };
 });


### PR DESCRIPTION
Closes #18.

## Issue #18 — new sources

| Source | ATS | Filter | Current matches |
|---|---|---|---|
| **Appnovation Technologies** | Greenhouse | Atlassian-relevant titles | 1 (`Atlassian Consultant (Jira Align)`) |
| **Empyra** | Keka JSON API | none — Platinum partner / Marketplace app vendor | 4 (Bangalore/Costa Rica) |
| **Sngular** | static HTML | Atlassian-relevant titles | 0 currently (dormant) |

Smoke-tested `--only=appnovation,empyra,sngular` → +5 jobs, 0 anomalies.

### Issue #18 — Directio "regression" is a false alarm
Cited `Atlassian Administrator` role at `directio.teamtailor.com/jobs/7634714-…` returns **HTTP 410 Gone**. Real closure, not a scraper bug. Teamtailor RSS engine parses all 41 of Directio's current feed items correctly. No engine change needed.

### Issue #18 — 5 of 8 suggested sources skipped
| Source | Reason |
|---|---|
| Trundl | No public job listings — generic "join us" page |
| M20 Technology | No public job listings |
| PractiProject | No careers content on home page |
| Rego Consulting | Page lists "role profile *examples*", not live openings |
| Ariel Partners | CATS One React-rendered, needs Playwright |

---

## Weekly maintenance (separate commit)

- **`index.astro`** — substantial JobPosting JSON-LD fixes
  - 20+ new country codes (CA, NL, BE, LU, IE, SE, FI, PL, PT, ES, IT, BG, HU, CH, MA, TN, EG, AE, MY, PH, AR, BR, CR)
  - drop wrong "fallback to AU" — return null instead so unknown locations don't lie in the schema
  - for remote roles, emit `jobLocationType: TELECOMMUTE` + `applicantLocationRequirements` per Google's spec (was emitting a fake `jobLocation.addressCountry`)
  - treat broad regions (Europe, LatAm, Asia, Africa, "global") as remote
  - coerce `locationNormalised` to array defensively (older data may be plain string)
- **`greenhouse-sources.ts`** — add Valtech, Braze, Conga with title filter (dormant pattern, same as Samsara/Kalles)
- **`oxalis.ts`** — log+return-empty on HTTP error instead of throwing, so a URL change doesn't keep the source in cooldown forever

`npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)